### PR TITLE
fix(frontend): Write button works on the first screen

### DIFF
--- a/frontend/app/src/pages/main.tsx
+++ b/frontend/app/src/pages/main.tsx
@@ -26,7 +26,6 @@ export default function Main() {
       <div className={classnames('main-root', {settings: isSettings})}>
         <main>
           <Switch>
-            <Route path="/" component={PublicationList} />
             <Route path="/inbox" component={PublicationList} />
             <Route path="/drafts" component={DraftList} />
             <Route


### PR DESCRIPTION
for some reason the window rust code does not open the new window with the new draft URL when the current URL is the root (`tauri://localhost`). it does work with other routes.

This removes the route match to the root URL in order to avoid having this error. but this is something that needs to be addressed in the Rust code.

solves #1051 