### PR TITLE
feat: add better children types + tests

### DIFF
--- a/frontend/apps/desktop/src/blocknote-core/extensions/Blocks/api/defaultBlocks.ts
+++ b/frontend/apps/desktop/src/blocknote-core/extensions/Blocks/api/defaultBlocks.ts
@@ -23,7 +23,7 @@ export const defaultBlockSchema = {
   paragraph: {
     propSchema: {
       ...defaultProps,
-      type: {default: 'p', values: ['p', 'blockquote'] as const},
+      type: {default: 'p', values: ['p'] as const},
     },
     node: ParagraphBlockContent,
   },

--- a/frontend/apps/desktop/src/blocknote-core/extensions/Blocks/nodes/BlockContent/ParagraphBlockContent/ParagraphBlockContent.ts
+++ b/frontend/apps/desktop/src/blocknote-core/extensions/Blocks/nodes/BlockContent/ParagraphBlockContent/ParagraphBlockContent.ts
@@ -54,12 +54,6 @@ export const ParagraphBlockContent = createTipTapBlock<'paragraph'>({
         attrs: {type: 'p'},
         node: 'paragraph',
       },
-      {
-        tag: 'blockquote',
-        priority: 200,
-        attrs: {type: 'blockquote'},
-        node: 'paragraph',
-      },
     ]
   },
 

--- a/frontend/apps/desktop/src/blocknote-core/extensions/SlashMenu/defaultSlashMenuItems.tsx
+++ b/frontend/apps/desktop/src/blocknote-core/extensions/SlashMenu/defaultSlashMenuItems.tsx
@@ -99,16 +99,6 @@ export const defaultSlashMenuItems = [
   // ),
 
   new BaseSlashMenuItem<HDBlockSchema>(
-    'Blockquote',
-    (editor) =>
-      insertOrUpdateBlock(editor, {
-        type: 'paragraph',
-        props: {type: 'blockquote'},
-      }),
-    ['blockquote'],
-  ),
-
-  new BaseSlashMenuItem<HDBlockSchema>(
     'Video / Audio',
     (editor) =>
       insertOrUpdateBlock(editor, {

--- a/frontend/apps/desktop/src/client/__tests__/editor-to-server.test.ts
+++ b/frontend/apps/desktop/src/client/__tests__/editor-to-server.test.ts
@@ -207,3 +207,113 @@ describe('editorBlockToServerBlock', () => {
   //   })
   // })
 })
+
+describe('blockGroup types', () => {
+  test('Default list', () => {
+    const eBlock = editorBlockToServerBlock({
+      id: 'abc',
+      type: 'paragraph',
+      content: [],
+      props: {
+        ref: 'hd://foo',
+        // why is this garbage required for embed props??:
+        backgroundColor: 'default',
+        textColor: 'default',
+        textAlignment: 'left',
+        childrenType: 'group',
+      },
+      children: [],
+    })
+    expect(eBlock).toEqual(
+      new Block({
+        id: 'abc',
+        type: 'paragraph',
+        attributes: {
+          childrenType: 'group',
+        },
+      }),
+    )
+  })
+
+  test('Unordered list', () => {
+    const eBlock = editorBlockToServerBlock({
+      id: 'abc',
+      type: 'paragraph',
+
+      content: [],
+      props: {
+        ref: 'hd://foo',
+        // why is this garbage required for embed props??:
+        backgroundColor: 'default',
+        textColor: 'default',
+        textAlignment: 'left',
+        childrenType: 'ul',
+      },
+      children: [],
+    })
+    expect(eBlock).toEqual(
+      new Block({
+        id: 'abc',
+        type: 'paragraph',
+        attributes: {
+          childrenType: 'ul',
+        },
+      }),
+    )
+  })
+
+  test('Ordered list', () => {
+    const eBlock = editorBlockToServerBlock({
+      id: 'abc',
+      type: 'paragraph',
+
+      content: [],
+      props: {
+        ref: 'hd://foo',
+        // why is this garbage required for embed props??:
+        backgroundColor: 'default',
+        textColor: 'default',
+        textAlignment: 'left',
+        childrenType: 'ol',
+        start: '2',
+      },
+      children: [],
+    })
+    expect(eBlock).toEqual(
+      new Block({
+        id: 'abc',
+        type: 'paragraph',
+        attributes: {
+          childrenType: 'ol',
+          start: '2',
+        },
+      }),
+    )
+  })
+  test('Blockquote list', () => {
+    const eBlock = editorBlockToServerBlock({
+      id: 'abc',
+      type: 'paragraph',
+
+      content: [],
+      props: {
+        ref: 'hd://foo',
+        // why is this garbage required for embed props??:
+        backgroundColor: 'default',
+        textColor: 'default',
+        textAlignment: 'left',
+        childrenType: 'blockquote',
+      },
+      children: [],
+    })
+    expect(eBlock).toEqual(
+      new Block({
+        id: 'abc',
+        type: 'paragraph',
+        attributes: {
+          childrenType: 'blockquote',
+        },
+      }),
+    )
+  })
+})

--- a/frontend/apps/desktop/src/client/__tests__/server-to-editor.test.ts
+++ b/frontend/apps/desktop/src/client/__tests__/server-to-editor.test.ts
@@ -4,398 +4,507 @@ import {serverChildrenToEditorChildren} from '../server-to-editor'
 import {examples} from '../example-docs'
 import {InlineContent} from '@app/blocknote-core'
 
-describe('Editor: ', () => {
-  describe('Server to Editor: ', () => {
-    test('empty/basic', () => {
-      expect(serverChildrenToEditorChildren([])).toEqual([])
-    })
-    test('single empty paragraph', () => {
-      const eChildren = serverChildrenToEditorChildren([
-        new BlockNode({
-          block: new Block({id: 'a', type: 'section', text: ''}),
-        }),
-      ])
-      expect(eChildren).toEqual([
-        {
-          id: 'a',
-          type: 'paragraph',
-          props: {},
-          content: [],
-          children: [],
-        },
-      ])
-    })
-    test('single paragraph', () => {
-      const eChildren = serverChildrenToEditorChildren([
-        new BlockNode({
-          block: new Block({id: 'a', type: 'section', text: 'hello'}),
-        }),
-      ])
-      expect(eChildren).toEqual([
-        {
-          id: 'a',
-          type: 'paragraph',
-          props: {},
-          content: [{text: 'hello', type: 'text', styles: {}}],
-          children: [],
-        },
-      ])
-    })
-    test('two paragraphs', () => {
-      const eChildren = serverChildrenToEditorChildren([
-        new BlockNode({
-          block: new Block({id: 'a', type: 'section', text: 'hello'}),
-        }),
-        new BlockNode({
-          block: new Block({id: 'b', type: 'section', text: 'world'}),
-        }),
-      ])
-      expect(eChildren).toEqual([
-        {
-          id: 'a',
-          type: 'paragraph',
-          props: {},
-          content: [{text: 'hello', type: 'text', styles: {}}],
-          children: [],
-        },
-        {
-          id: 'b',
-          type: 'paragraph',
-          props: {},
-          content: [{text: 'world', type: 'text', styles: {}}],
-          children: [],
-        },
-      ])
-    })
-
-    test('bolding', () => {
-      const eChildren = serverChildrenToEditorChildren(
-        examples.withBoldText.children,
-      )
-      expect(eChildren).toEqual([
-        {
-          id: '1',
-          type: 'paragraph',
-          props: {},
-          content: [
-            {text: 'hello ', type: 'text', styles: {}},
-            {text: 'world', type: 'text', styles: {bold: true}},
-            {text: '!', type: 'text', styles: {}},
-          ],
-          children: [],
-        },
-      ])
-    })
-
-    test('overlap annotations', () => {
-      const eChildren = serverChildrenToEditorChildren(
-        examples.withOverlappingAnnotations.children,
-      )
-      expect(eChildren).toEqual([
-        {
-          id: '1',
-          type: 'paragraph',
-          props: {},
-          content: [
-            {text: 'A', type: 'text', styles: {}},
-            {text: 'B', type: 'text', styles: {bold: true}},
-            {text: 'C', type: 'text', styles: {bold: true, italic: true}},
-            {text: 'D', type: 'text', styles: {italic: true}},
-            {text: 'E', type: 'text', styles: {}},
-          ],
-          children: [],
-        },
-      ])
-    })
+describe('Server to Editor: ', () => {
+  test('empty/basic', () => {
+    expect(serverChildrenToEditorChildren([])).toEqual([])
+  })
+  test('single empty paragraph', () => {
+    const eChildren = serverChildrenToEditorChildren([
+      new BlockNode({
+        block: new Block({id: 'a', type: 'section', text: ''}),
+      }),
+    ])
+    expect(eChildren).toEqual([
+      {
+        id: 'a',
+        type: 'paragraph',
+        props: {},
+        content: [],
+        children: [],
+      },
+    ])
+  })
+  test('single paragraph', () => {
+    const eChildren = serverChildrenToEditorChildren([
+      new BlockNode({
+        block: new Block({id: 'a', type: 'section', text: 'hello'}),
+      }),
+    ])
+    expect(eChildren).toEqual([
+      {
+        id: 'a',
+        type: 'paragraph',
+        props: {},
+        content: [{text: 'hello', type: 'text', styles: {}}],
+        children: [],
+      },
+    ])
+  })
+  test('two paragraphs', () => {
+    const eChildren = serverChildrenToEditorChildren([
+      new BlockNode({
+        block: new Block({id: 'a', type: 'section', text: 'hello'}),
+      }),
+      new BlockNode({
+        block: new Block({id: 'b', type: 'section', text: 'world'}),
+      }),
+    ])
+    expect(eChildren).toEqual([
+      {
+        id: 'a',
+        type: 'paragraph',
+        props: {},
+        content: [{text: 'hello', type: 'text', styles: {}}],
+        children: [],
+      },
+      {
+        id: 'b',
+        type: 'paragraph',
+        props: {},
+        content: [{text: 'world', type: 'text', styles: {}}],
+        children: [],
+      },
+    ])
   })
 
-  describe('Server Block to Editor Inline: ', () => {
-    test('no annotations', () => {
-      const result: InlineContent[] = serverBlockToEditorInline(
-        new Block({text: 'ABC', annotations: []}),
-      )
-      expect(result.length).toEqual(1)
-      const i0 = result[0]
-      expect(i0).toEqual({
-        type: 'text',
+  test('bolding', () => {
+    const eChildren = serverChildrenToEditorChildren(
+      examples.withBoldText.children,
+    )
+    expect(eChildren).toEqual([
+      {
+        id: '1',
+        type: 'paragraph',
+        props: {},
+        content: [
+          {text: 'hello ', type: 'text', styles: {}},
+          {text: 'world', type: 'text', styles: {bold: true}},
+          {text: '!', type: 'text', styles: {}},
+        ],
+        children: [],
+      },
+    ])
+  })
+
+  test('overlap annotations', () => {
+    const eChildren = serverChildrenToEditorChildren(
+      examples.withOverlappingAnnotations.children,
+    )
+    expect(eChildren).toEqual([
+      {
+        id: '1',
+        type: 'paragraph',
+        props: {},
+        content: [
+          {text: 'A', type: 'text', styles: {}},
+          {text: 'B', type: 'text', styles: {bold: true}},
+          {text: 'C', type: 'text', styles: {bold: true, italic: true}},
+          {text: 'D', type: 'text', styles: {italic: true}},
+          {text: 'E', type: 'text', styles: {}},
+        ],
+        children: [],
+      },
+    ])
+  })
+})
+
+describe('Server Block to Editor Inline: ', () => {
+  test('no annotations', () => {
+    const result: InlineContent[] = serverBlockToEditorInline(
+      new Block({text: 'ABC', annotations: []}),
+    )
+    expect(result.length).toEqual(1)
+    const i0 = result[0]
+    expect(i0).toEqual({
+      type: 'text',
+      text: 'ABC',
+      styles: {},
+    })
+  })
+  test('basic annotation', () => {
+    const result: InlineContent[] = serverBlockToEditorInline(
+      new Block({
         text: 'ABC',
-        styles: {},
-      })
-    })
-    test('basic annotation', () => {
-      const result: InlineContent[] = serverBlockToEditorInline(
-        new Block({
-          text: 'ABC',
-          annotations: [
-            {type: 'strong', starts: [1], ends: [2], attributes: {}},
-          ],
-        }),
-      )
-      expect(result).toEqual([
-        {text: 'A', type: 'text', styles: {}},
-        {text: 'B', type: 'text', styles: {bold: true}},
-        {text: 'C', type: 'text', styles: {}},
-      ])
-    })
-
-    test('simple marks kitchen sink', () => {
-      const result: InlineContent[] = serverBlockToEditorInline(
-        new Block({
-          text: '01234',
-          annotations: [
-            {type: 'strong', starts: [0], ends: [1], attributes: {}},
-            {type: 'emphasis', starts: [1], ends: [2], attributes: {}},
-            {type: 'underline', starts: [2], ends: [3], attributes: {}},
-            {type: 'strike', starts: [3], ends: [4], attributes: {}},
-            {type: 'code', starts: [4], ends: [5], attributes: {}},
-          ],
-        }),
-      )
-      expect(result).toEqual([
-        {text: '0', type: 'text', styles: {bold: true}},
-        {text: '1', type: 'text', styles: {italic: true}},
-        {text: '2', type: 'text', styles: {underline: true}},
-        {text: '3', type: 'text', styles: {strike: true}},
-        {text: '4', type: 'text', styles: {code: true}},
-      ])
-    })
-
-    test('overlapping annotations', () => {
-      const result: InlineContent[] = serverBlockToEditorInline(
-        // A - no style
-        // B - bold
-        // C - bold + italic
-        // D - italic
-        // E - no style
-        new Block({
-          text: 'ABCDE',
-          annotations: [
-            {
-              type: 'strong',
-              starts: [1],
-              ends: [3],
-            },
-            {
-              type: 'emphasis',
-              starts: [2],
-              ends: [4],
-            },
-          ],
-        }),
-      )
-      expect(result).toEqual([
-        {text: 'A', type: 'text', styles: {}},
-        {text: 'B', type: 'text', styles: {bold: true}},
-        {text: 'C', type: 'text', styles: {bold: true, italic: true}},
-        {text: 'D', type: 'text', styles: {italic: true}},
-        {text: 'E', type: 'text', styles: {}},
-      ])
-    })
-
-    test('link annotation', () => {
-      const result: InlineContent[] = serverBlockToEditorInline(
-        new Block({
-          text: 'a link',
-          annotations: [
-            {
-              type: 'link',
-              ref: 'http://example.com',
-              starts: [2],
-              ends: [6],
-            },
-          ],
-        }),
-      )
-      expect(result).toEqual([
-        {text: 'a ', type: 'text', styles: {}},
-        {
-          type: 'link',
-          href: 'http://example.com',
-          content: [{text: 'link', type: 'text', styles: {}}],
-        },
-      ])
-    })
-
-    test('two link annotations', () => {
-      const result: InlineContent[] = serverBlockToEditorInline(
-        new Block({
-          text: 'ok link ok link ok',
-          annotations: [
-            {
-              type: 'link',
-              ref: 'http://1',
-              starts: [3],
-              ends: [7],
-            },
-            {
-              type: 'link',
-              ref: 'http://2',
-              starts: [11],
-              ends: [15],
-            },
-          ],
-        }),
-      )
-      expect(result).toEqual([
-        {text: 'ok ', type: 'text', styles: {}},
-        {
-          type: 'link',
-          href: 'http://1',
-          content: [{text: 'link', type: 'text', styles: {}}],
-        },
-        {text: ' ok ', type: 'text', styles: {}},
-        {
-          type: 'link',
-          href: 'http://2',
-          content: [{text: 'link', type: 'text', styles: {}}],
-        },
-        {text: ' ok', type: 'text', styles: {}},
-      ])
-    })
-
-    test('link annotation with bold inside', () => {
-      const result: InlineContent[] = serverBlockToEditorInline(
-        new Block({
-          text: 'a strong link',
-          annotations: [
-            {
-              type: 'link',
-              ref: 'http://example.com',
-              starts: [2],
-              ends: [13],
-            },
-            {
-              type: 'strong',
-              starts: [2],
-              ends: [8],
-            },
-          ],
-        }),
-      )
-      expect(result).toEqual([
-        {text: 'a ', type: 'text', styles: {}},
-        {
-          type: 'link',
-          href: 'http://example.com',
-          content: [
-            {text: 'strong', type: 'text', styles: {bold: true}},
-            {text: ' link', type: 'text', styles: {}},
-          ],
-        },
-      ])
-    })
+        annotations: [{type: 'strong', starts: [1], ends: [2], attributes: {}}],
+      }),
+    )
+    expect(result).toEqual([
+      {text: 'A', type: 'text', styles: {}},
+      {text: 'B', type: 'text', styles: {bold: true}},
+      {text: 'C', type: 'text', styles: {}},
+    ])
   })
 
-  describe('Server Image Block to Editor: ', () => {
-    test('basic', () => {
-      const result = serverChildrenToEditorChildren([
-        new BlockNode({
-          block: new Block({
-            id: 'a',
-            type: 'image',
-            text: 'new alt image',
-            annotations: [],
-            attributes: {},
-            ref: 'ipfs://ABC',
-          }),
-        }),
-      ])
-      expect(result).toEqual([
-        {
+  test('simple marks kitchen sink', () => {
+    const result: InlineContent[] = serverBlockToEditorInline(
+      new Block({
+        text: '01234',
+        annotations: [
+          {type: 'strong', starts: [0], ends: [1], attributes: {}},
+          {type: 'emphasis', starts: [1], ends: [2], attributes: {}},
+          {type: 'underline', starts: [2], ends: [3], attributes: {}},
+          {type: 'strike', starts: [3], ends: [4], attributes: {}},
+          {type: 'code', starts: [4], ends: [5], attributes: {}},
+        ],
+      }),
+    )
+    expect(result).toEqual([
+      {text: '0', type: 'text', styles: {bold: true}},
+      {text: '1', type: 'text', styles: {italic: true}},
+      {text: '2', type: 'text', styles: {underline: true}},
+      {text: '3', type: 'text', styles: {strike: true}},
+      {text: '4', type: 'text', styles: {code: true}},
+    ])
+  })
+
+  test('overlapping annotations', () => {
+    const result: InlineContent[] = serverBlockToEditorInline(
+      // A - no style
+      // B - bold
+      // C - bold + italic
+      // D - italic
+      // E - no style
+      new Block({
+        text: 'ABCDE',
+        annotations: [
+          {
+            type: 'strong',
+            starts: [1],
+            ends: [3],
+          },
+          {
+            type: 'emphasis',
+            starts: [2],
+            ends: [4],
+          },
+        ],
+      }),
+    )
+    expect(result).toEqual([
+      {text: 'A', type: 'text', styles: {}},
+      {text: 'B', type: 'text', styles: {bold: true}},
+      {text: 'C', type: 'text', styles: {bold: true, italic: true}},
+      {text: 'D', type: 'text', styles: {italic: true}},
+      {text: 'E', type: 'text', styles: {}},
+    ])
+  })
+
+  test('link annotation', () => {
+    const result: InlineContent[] = serverBlockToEditorInline(
+      new Block({
+        text: 'a link',
+        annotations: [
+          {
+            type: 'link',
+            ref: 'http://example.com',
+            starts: [2],
+            ends: [6],
+          },
+        ],
+      }),
+    )
+    expect(result).toEqual([
+      {text: 'a ', type: 'text', styles: {}},
+      {
+        type: 'link',
+        href: 'http://example.com',
+        content: [{text: 'link', type: 'text', styles: {}}],
+      },
+    ])
+  })
+
+  test('two link annotations', () => {
+    const result: InlineContent[] = serverBlockToEditorInline(
+      new Block({
+        text: 'ok link ok link ok',
+        annotations: [
+          {
+            type: 'link',
+            ref: 'http://1',
+            starts: [3],
+            ends: [7],
+          },
+          {
+            type: 'link',
+            ref: 'http://2',
+            starts: [11],
+            ends: [15],
+          },
+        ],
+      }),
+    )
+    expect(result).toEqual([
+      {text: 'ok ', type: 'text', styles: {}},
+      {
+        type: 'link',
+        href: 'http://1',
+        content: [{text: 'link', type: 'text', styles: {}}],
+      },
+      {text: ' ok ', type: 'text', styles: {}},
+      {
+        type: 'link',
+        href: 'http://2',
+        content: [{text: 'link', type: 'text', styles: {}}],
+      },
+      {text: ' ok', type: 'text', styles: {}},
+    ])
+  })
+
+  test('link annotation with bold inside', () => {
+    const result: InlineContent[] = serverBlockToEditorInline(
+      new Block({
+        text: 'a strong link',
+        annotations: [
+          {
+            type: 'link',
+            ref: 'http://example.com',
+            starts: [2],
+            ends: [13],
+          },
+          {
+            type: 'strong',
+            starts: [2],
+            ends: [8],
+          },
+        ],
+      }),
+    )
+    expect(result).toEqual([
+      {text: 'a ', type: 'text', styles: {}},
+      {
+        type: 'link',
+        href: 'http://example.com',
+        content: [
+          {text: 'strong', type: 'text', styles: {bold: true}},
+          {text: ' link', type: 'text', styles: {}},
+        ],
+      },
+    ])
+  })
+})
+
+describe('Server Image Block to Editor: ', () => {
+  test('basic', () => {
+    const result = serverChildrenToEditorChildren([
+      new BlockNode({
+        block: new Block({
           id: 'a',
           type: 'image',
-          props: {
-            url: 'ABC',
-            defaultOpen: 'false',
-            // junk:
-            backgroundColor: 'default',
-            textAlignment: 'left',
-            textColor: 'default',
-          },
-          content: [{type: 'text', text: 'new alt image', styles: {}}],
-        },
-      ])
-    })
-  })
-
-  describe('Server Embed Block to Editor: ', () => {
-    test('basic', () => {
-      const result = serverChildrenToEditorChildren([
-        new BlockNode({
-          block: new Block({
-            id: 'a',
-            type: 'embed',
-            text: '',
-            annotations: [],
-            attributes: {},
-            ref: 'hd://foobar',
-          }),
+          text: 'new alt image',
+          annotations: [],
+          attributes: {},
+          ref: 'ipfs://ABC',
         }),
-      ])
-      expect(result).toEqual([
-        {
+      }),
+    ])
+    expect(result).toEqual([
+      {
+        id: 'a',
+        type: 'image',
+        props: {
+          url: 'ABC',
+          defaultOpen: 'false',
+          // junk:
+          backgroundColor: 'default',
+          textAlignment: 'left',
+          textColor: 'default',
+        },
+        content: [{type: 'text', text: 'new alt image', styles: {}}],
+      },
+    ])
+  })
+})
+
+describe('Server Embed Block to Editor: ', () => {
+  test('basic', () => {
+    const result = serverChildrenToEditorChildren([
+      new BlockNode({
+        block: new Block({
           id: 'a',
           type: 'embed',
-          props: {
-            ref: 'hd://foobar',
-            // junk:
-            backgroundColor: 'default',
-            textAlignment: 'left',
-            textColor: 'default',
-          },
+          text: '',
+          annotations: [],
+          attributes: {},
+          ref: 'hd://foobar',
+        }),
+      }),
+    ])
+    expect(result).toEqual([
+      {
+        id: 'a',
+        type: 'embed',
+        props: {
+          ref: 'hd://foobar',
+          // junk:
+          backgroundColor: 'default',
+          textAlignment: 'left',
+          textColor: 'default',
         },
-      ])
-    })
+      },
+    ])
+  })
+})
+
+describe.only('Server Block to Editor ChildrenType: ', () => {
+  test('default list', () => {
+    const result = serverChildrenToEditorChildren([
+      new BlockNode({
+        block: new Block({
+          id: 'a',
+          type: 'paragraph',
+          text: 'hello world',
+          annotations: [],
+          attributes: {
+            childrenType: 'group',
+          },
+        }),
+      }),
+    ])
+
+    expect(result).toEqual([
+      {
+        id: 'a',
+        type: 'paragraph',
+        props: {
+          childrenType: 'group',
+        },
+        content: [{type: 'text', text: 'hello world', styles: {}}],
+        children: [],
+      },
+    ])
   })
 
-  // describe('Server Embed to Block Editor', () => {
-  //   test('simple embed', () => {
-  //     const result: InlineContent[] = serverBlockToEditorInline(
-  //       new Block({
-  //         text: ' ',
-  //         annotations: [
-  //           {
-  //             type: 'embed',
-  //             ref: 'hd://foobar',
-  //             starts: [0],
-  //             ends: [1],
-  //           },
-  //         ],
-  //       }),
-  //     )
-  //     expect(result).toEqual([{type: 'embed', ref: 'hd://foobar'}])
-  //   })
+  test('Ordered list', () => {
+    const result = serverChildrenToEditorChildren([
+      new BlockNode({
+        block: new Block({
+          id: 'a',
+          type: 'paragraph',
+          text: 'hello world',
+          annotations: [],
+          attributes: {
+            childrenType: 'ol',
+            start: '2',
+          },
+        }),
+      }),
+    ])
+    expect(result).toEqual([
+      {
+        id: 'a',
+        type: 'paragraph',
+        props: {
+          childrenType: 'ol',
+          start: '2',
+        },
+        content: [{type: 'text', text: 'hello world', styles: {}}],
+        children: [],
+      },
+    ])
+  })
 
-  //   test('overlapping annotations + embed', () => {
-  //     const result: InlineContent[] = serverBlockToEditorInline(
-  //       new Block({
-  //         text: 'ABC DE',
-  //         annotations: [
-  //           {
-  //             type: 'strong',
-  //             starts: [1],
-  //             ends: [3],
-  //           },
-  //           {
-  //             type: 'embed',
-  //             ref: 'hd://foobar',
-  //             starts: [3],
-  //             ends: [4],
-  //           },
-  //           {
-  //             type: 'emphasis',
-  //             starts: [4],
-  //             ends: [6],
-  //           },
-  //         ],
-  //       }),
-  //     )
-  //     expect(result).toEqual([
-  //       {text: 'A', type: 'text', styles: {}},
-  //       {text: 'BC', type: 'text', styles: {bold: true}},
-  //       {type: 'embed', ref: 'hd://foobar'},
-  //       {text: 'DE', type: 'text', styles: {italic: true}},
-  //     ])
-  //   })
-  // })
+  test('Unordered list', () => {
+    const result = serverChildrenToEditorChildren([
+      new BlockNode({
+        block: new Block({
+          id: 'a',
+          type: 'paragraph',
+          text: 'hello world',
+          annotations: [],
+          attributes: {
+            childrenType: 'ul',
+          },
+        }),
+      }),
+    ])
+    expect(result).toEqual([
+      {
+        id: 'a',
+        type: 'paragraph',
+        props: {
+          childrenType: 'ul',
+        },
+        content: [{type: 'text', text: 'hello world', styles: {}}],
+        children: [],
+      },
+    ])
+  })
+
+  test('Blockquote list', () => {
+    const result = serverChildrenToEditorChildren([
+      new BlockNode({
+        block: new Block({
+          id: 'a',
+          type: 'paragraph',
+          text: 'hello world',
+          annotations: [],
+          attributes: {
+            childrenType: 'blockquote',
+          },
+        }),
+      }),
+    ])
+    expect(result).toEqual([
+      {
+        id: 'a',
+        type: 'paragraph',
+        props: {
+          childrenType: 'blockquote',
+        },
+        content: [{type: 'text', text: 'hello world', styles: {}}],
+        children: [],
+      },
+    ])
+  })
 })
+
+// describe('Server Embed to Block Editor', () => {
+//   test('simple embed', () => {
+//     const result: InlineContent[] = serverBlockToEditorInline(
+//       new Block({
+//         text: ' ',
+//         annotations: [
+//           {
+//             type: 'embed',
+//             ref: 'hd://foobar',
+//             starts: [0],
+//             ends: [1],
+//           },
+//         ],
+//       }),
+//     )
+//     expect(result).toEqual([{type: 'embed', ref: 'hd://foobar'}])
+//   })
+
+//   test('overlapping annotations + embed', () => {
+//     const result: InlineContent[] = serverBlockToEditorInline(
+//       new Block({
+//         text: 'ABC DE',
+//         annotations: [
+//           {
+//             type: 'strong',
+//             starts: [1],
+//             ends: [3],
+//           },
+//           {
+//             type: 'embed',
+//             ref: 'hd://foobar',
+//             starts: [3],
+//             ends: [4],
+//           },
+//           {
+//             type: 'emphasis',
+//             starts: [4],
+//             ends: [6],
+//           },
+//         ],
+//       }),
+//     )
+//     expect(result).toEqual([
+//       {text: 'A', type: 'text', styles: {}},
+//       {text: 'BC', type: 'text', styles: {bold: true}},
+//       {type: 'embed', ref: 'hd://foobar'},
+//       {text: 'DE', type: 'text', styles: {italic: true}},
+//     ])
+//   })
+// })

--- a/frontend/apps/desktop/src/client/editor-to-server.ts
+++ b/frontend/apps/desktop/src/client/editor-to-server.ts
@@ -112,18 +112,18 @@ export function editorBlockToServerBlock(
   editorBlock: EditorBlock<typeof hdBlockSchema>,
 ): ServerBlock {
   if (!editorBlock.id) throw new Error('this block has no id')
+
+  let res: ServerBlock | null = null
   if (editorBlock.type === 'paragraph') {
-    return new ServerBlock({
+    res = new ServerBlock({
       id: editorBlock.id,
       type: 'paragraph',
-      attributes: {
-        type: editorBlock.props.type,
-      },
+      attributes: {},
       ...extractContent(editorBlock.content),
     })
   }
   if (editorBlock.type === 'heading') {
-    return new ServerBlock({
+    res = new ServerBlock({
       id: editorBlock.id,
       type: 'heading',
       attributes: {},
@@ -131,7 +131,7 @@ export function editorBlockToServerBlock(
     })
   }
   if (editorBlock.type === 'image') {
-    return new ServerBlock({
+    res = new ServerBlock({
       id: editorBlock.id,
       type: 'image',
       attributes: {},
@@ -141,7 +141,7 @@ export function editorBlockToServerBlock(
   }
 
   if (editorBlock.type === 'file') {
-    return new ServerBlock({
+    res = new ServerBlock({
       id: editorBlock.id,
       type: 'file',
       attributes: {
@@ -152,7 +152,7 @@ export function editorBlockToServerBlock(
   }
 
   if (editorBlock.type == 'embed') {
-    return new ServerBlock({
+    res = new ServerBlock({
       id: editorBlock.id,
       type: 'embed',
       ref: editorBlock.props.ref,
@@ -161,5 +161,25 @@ export function editorBlockToServerBlock(
       attributes: {},
     })
   }
+
+  if (res) {
+    res = extractChildrenType(res, editorBlock)
+    return res
+  }
   throw new Error('not implemented')
+}
+
+function extractChildrenType(
+  block: ServerBlock,
+  editorBlock: EditorBlock<typeof hdBlockSchema>,
+): ServerBlock {
+  if (editorBlock.props.childrenType) {
+    block.attributes.childrenType = editorBlock.props.childrenType
+  }
+
+  if (editorBlock.props.start) {
+    block.attributes.start = editorBlock.props.start
+  }
+
+  return block
 }

--- a/frontend/apps/desktop/src/client/example-docs.ts
+++ b/frontend/apps/desktop/src/client/example-docs.ts
@@ -3,7 +3,7 @@ import {
   Block,
   BlockNode,
   Document,
-  SectionBlockAttributes,
+  HDBlockAttributes,
 } from '@mintter/shared'
 
 function createAnnotation(
@@ -47,7 +47,7 @@ function createSectionNode(
     type?: 'section' | 'paragraph' | 'heading'
     id: string
     annotations?: Annotation[]
-    attributes?: SectionBlockAttributes
+    attributes?: HDBlockAttributes
   },
   children?: BlockNode[],
 ) {
@@ -111,7 +111,7 @@ export const examples = {
           text: 'this is a list:',
           id: '1',
           attributes: {
-            childrenType: 'bullet',
+            childrenType: 'ul',
           },
         },
         [
@@ -142,13 +142,13 @@ export const examples = {
           text: 'this is a list:',
           id: '1',
           attributes: {
-            childrenType: 'bullet',
+            childrenType: 'ul',
           },
         },
         [
           createSectionNode({text: 'item 1', id: '2'}),
           createSectionNode(
-            {text: 'item 2', id: '3', attributes: {childrenType: 'numbers'}},
+            {text: 'item 2', id: '3', attributes: {childrenType: 'ol'}},
             [
               createSectionNode({text: 'numbered A', id: 'a'}),
               createSectionNode({text: 'numbered B', id: 'b'}),

--- a/frontend/apps/desktop/src/embed-block.tsx
+++ b/frontend/apps/desktop/src/embed-block.tsx
@@ -1,4 +1,15 @@
+import {
+  Block as BlockNoteBlock,
+  BlockNoteEditor,
+  InlineContent,
+} from '@app/blocknote-core'
 import {PartialMessage} from '@bufbuild/protobuf'
+import type {
+  Block as ServerBlock,
+  BlockNode,
+  ImageBlock,
+  PresentationBlock,
+} from '@mintter/shared'
 import {
   Block,
   getCIDFromIPFSUrl,
@@ -6,25 +17,13 @@ import {
   isHyperdocsScheme,
   serverBlockToEditorInline,
 } from '@mintter/shared'
-import type {
-  Block as ServerBlock,
-  PresentationBlock,
-  BlockNode,
-  SectionBlock,
-  ImageBlock,
-} from '@mintter/shared'
-import {YStack, Text, Spinner} from '@mintter/ui'
+import {Spinner, Text, YStack} from '@mintter/ui'
 import {useEffect, useMemo, useState} from 'react'
-import {createReactBlockSpec} from './blocknote-react'
-import {usePublication} from './models/documents'
-import {
-  InlineContent,
-  Block as BlockNoteBlock,
-  BlockNoteEditor,
-} from '@app/blocknote-core'
-import {openUrl} from './utils/open-url'
 import {getBlockInfoFromPos} from './blocknote-core/extensions/Blocks/helpers/getBlockInfoFromPos'
+import {createReactBlockSpec} from './blocknote-react'
 import {hdBlockSchema} from './client/schema'
+import {usePublication} from './models/documents'
+import {openUrl} from './utils/open-url'
 
 function InlineContentView({inline}: {inline: InlineContent[]}) {
   return (
@@ -77,7 +76,7 @@ function InlineContentView({inline}: {inline: InlineContent[]}) {
   )
 }
 
-function StaticSectionBlock({block}: {block: SectionBlock}) {
+function StaticPresentationBlock({block}: {block: PresentationBlock}) {
   const inline = useMemo(
     () => serverBlockToEditorInline(new Block(block)),
     [block],
@@ -99,7 +98,7 @@ function StaticBlock({block}: {block: ServerBlock}) {
   let niceBlock = block as PresentationBlock // todo, validation
 
   if (niceBlock.type === 'paragraph' || niceBlock.type === 'heading') {
-    return <StaticSectionBlock block={niceBlock} />
+    return <StaticPresentationBlock block={niceBlock} />
   }
   if (niceBlock.type === 'image') {
     return <StaticImageBlock block={niceBlock} />

--- a/frontend/apps/site/publication-page.tsx
+++ b/frontend/apps/site/publication-page.tsx
@@ -1,10 +1,10 @@
+/* eslint-disable @next/next/no-img-element */
 import {
   Account,
   ImageBlock,
   EmbedBlock,
   InlineContent,
   PresentationBlock,
-  SectionBlock,
   SiteInfo,
   getCIDFromIPFSUrl,
   serverBlockToEditorInline,
@@ -220,13 +220,13 @@ function InlineContentView({
   )
 }
 
-function StaticSectionBlock({block}: {block: SectionBlock}) {
+function StaticPresentationBlock({block}: {block: PresentationBlock}) {
   const inline = useMemo(
     () => serverBlockToEditorInline(new Block(block)),
     [block],
   )
-  const isBlockquote = block.attributes?.type === 'blockquote'
   return (
+<<<<<<< Updated upstream
     <YStack
       id={`${block.id}-block`}
       paddingLeft={isBlockquote ? 20 : 0}
@@ -241,6 +241,15 @@ function StaticSectionBlock({block}: {block: SectionBlock}) {
           }}
         />
       </Text>
+=======
+    <YStack id={`${block.id}-block`}>
+      <InlineContentView
+        inline={inline}
+        style={{
+          heading: block.type === 'heading',
+        }}
+      />
+>>>>>>> Stashed changes
     </YStack>
   )
 }
@@ -318,13 +327,13 @@ function StaticBlock({block}: {block: HDBlock}) {
   let niceBlock = block as PresentationBlock // todo, validation
 
   if (niceBlock.type === 'paragraph' || niceBlock.type === 'heading') {
-    return <StaticSectionBlock block={niceBlock} />
+    return <StaticPresentationBlock block={niceBlock} />
   }
   // legacy node
   // @ts-expect-error
   if (niceBlock.type === 'statement') {
     return (
-      <StaticSectionBlock
+      <StaticPresentationBlock
         block={{
           type: 'paragraph',
           // @ts-expect-error
@@ -347,7 +356,9 @@ function StaticBlock({block}: {block: HDBlock}) {
   // return <span>{JSON.stringify(block)}</span>
   return (
     <ErrorMessageBlock
+      // @ts-expect-error
       id={`${niceBlock.id}-block`}
+      // @ts-expect-error
       message={`Unknown block type: "${niceBlock.type}"`}
     />
   )

--- a/frontend/packages/shared/src/client/editor-types.ts
+++ b/frontend/packages/shared/src/client/editor-types.ts
@@ -1,3 +1,5 @@
+import {HDBlockChildrenType} from './hyperdocs-presentation'
+
 export type Styles = {
   bold?: true
   italic?: true
@@ -34,49 +36,58 @@ export type PartialLink = Omit<Link, 'content'> & {
 
 export type InlineContent = StyledText | Link
 export type PartialInlineContent = StyledText | PartialLink
+export type EditorBlockProps<T = unknown> = {
+  childrenType?: HDBlockChildrenType
+  start?: string
+  backgroundColor?: string
+  textColor?: string
+  textAlignment?: string
+  defaultOpen?: string
+} & T
 
 export type EditorParagraphBlock = {
   type: 'paragraph'
   id: string
   content: InlineContent[]
   children: EditorBlock[]
-  props: {
-    type: 'p' | 'blockquote'
-  }
+  props: EditorBlockProps
 }
 export type EditorHeadingBlock = {
   type: 'heading'
   id: string
   content: InlineContent[]
   children: EditorBlock[]
-  props: {
+  props: EditorBlockProps<{
     level: '1' | '2' | '3'
-  }
+  }>
 }
 export type EditorImageBlock = {
   type: 'image'
   id: string
-  props: {
+  props: EditorBlockProps<{
     url: string
-  }
+  }>
   content: InlineContent[]
+  children: EditorBlock[]
 }
 
 export type EditorFileBlock = {
   type: 'file'
   id: string
-  props: {
+  props: EditorBlockProps<{
     url: string
     name: string
-  }
+  }>
+  children: EditorBlock[]
 }
 
 export type EditorEmbedBlock = {
   type: 'embed'
   id: string
-  props: {
+  props: EditorBlockProps<{
     ref: string
-  }
+  }>
+  children: EditorBlock[]
 }
 
 export type EditorBlock =

--- a/frontend/packages/shared/src/client/hyperdocs-presentation.ts
+++ b/frontend/packages/shared/src/client/hyperdocs-presentation.ts
@@ -1,28 +1,24 @@
-export type ImageBlock = {
-  // and any media object really
-  id: string
-  type: 'image'
-  content: ''
-  annotations: []
-  ref: string // ipfs://..., https://...
-  attributes: {
-    alt?: string
-  }
-}
+export type HDBlockChildrenType = 'group' | 'ol' | 'ul' | 'blockquote'
 
-export type SectionBlockAttributes = {
-  type?: 'blockquote' | 'p'
-  childrenType?: 'group' | 'numbers' | 'bullet' | 'blockquote' // default is "group"
-  showContent?: string // interpret as a bool
-  isContentHeading?: string // interpret as a bool
+export type HDBlockAttributes = {
+  childrenType?: HDBlockChildrenType // default is "group"
   start?: string // interpret as a number
+  showContent?: string // interpret as a bool
 }
 
-export type SectionBlock = {
+export type ParagraphBlock = {
   id: string
-  type: 'heading' | 'paragraph'
+  type: 'paragraph'
   text: string
-  attributes: SectionBlockAttributes
+  attributes: HDBlockAttributes
+  annotations: TextAnnotation[]
+}
+
+export type HeadingBlock = {
+  id: string
+  type: 'heading'
+  text: string
+  attributes: HDBlockAttributes
   annotations: TextAnnotation[]
 }
 
@@ -35,18 +31,31 @@ export type CodeBlock = {
   }
 }
 
+export type ImageBlock = {
+  // and any media object really
+  id: string
+  type: 'image'
+  content: ''
+  annotations: []
+  ref: string // ipfs://..., https://...
+  attributes: HDBlockAttributes & {
+    alt?: string
+  }
+}
+
 export type EmbedBlock = {
   id: string
   type: 'embed'
   content: ''
   ref: string // ipfs://..., https://...
-  attributes: {}
+  attributes: HDBlockAttributes
 }
 
 export type PresentationBlock =
   | ImageBlock // video and files coming soon
   | EmbedBlock
-  | SectionBlock
+  | ParagraphBlock
+  | HeadingBlock
   | CodeBlock
 
 export type InlineEmbedAnnotation = {

--- a/frontend/packages/shared/src/client/server-to-editor.ts
+++ b/frontend/packages/shared/src/client/server-to-editor.ts
@@ -5,7 +5,7 @@ import {
   BlockNode,
 } from './.generated/documents/v1alpha/documents_pb'
 import {EditorBlock, InlineContent, StyledText} from './editor-types'
-import {TextAnnotation} from './hyperdocs-presentation'
+import {HDBlockChildrenType, TextAnnotation} from './hyperdocs-presentation'
 // import {Annotation, Block, BlockNode, TextAnnotation} from '@mintter/shared'
 // import {hdBlockSchema} from './schema'
 
@@ -167,7 +167,7 @@ export function partialBlockToStyledText({
   return inlines
 }
 
-export type EditorChildrenType = 'group' | 'numbers' | 'bullet' | 'blockquote'
+export type EditorChildrenType = HDBlockChildrenType
 
 export type ServerToEditorRecursiveOpts = {
   headingLevel: number
@@ -177,8 +177,8 @@ function extractChildrenType(
   childrenType: string | undefined,
 ): EditorChildrenType {
   if (!childrenType) return 'group'
-  if (childrenType === 'numbers') return 'numbers'
-  if (childrenType === 'bullet') return 'bullet'
+  if (childrenType === 'ol') return 'ol'
+  if (childrenType === 'ul') return 'ul'
   if (childrenType === 'blockquote') return 'blockquote'
   throw new Error('Unknown childrenType block attr: ' + childrenType)
 }
@@ -200,11 +200,9 @@ export function serverBlockNodeToEditorParagraph(
     content: serverBlockToEditorInline(block),
     children: serverChildrenToEditorChildren(children, {
       ...opts,
-      childrenType: extractChildrenType(block.attributes.childrenType),
+      childrenType: block.attributes.childrenType as HDBlockChildrenType,
     }),
-    props: {
-      type: serverBlock.block.attributes.type as 'p' | 'blockquote',
-    },
+    props: {},
   }
 }
 
@@ -237,14 +235,16 @@ export function serverChildrenToEditorChildren(
   children: BlockNode[],
   opts?: ServerToEditorRecursiveOpts & {
     childrenType?: EditorChildrenType
+    start?: string
   },
 ): EditorBlock[] {
   const childRecursiveOpts: ServerToEditorRecursiveOpts = {
     headingLevel: opts?.headingLevel || 0,
   }
   return children.map((serverBlock) => {
+    let res: EditorBlock | null = null
     if (serverBlock.block?.type === 'image') {
-      return {
+      res = {
         type: 'image',
         id: serverBlock.block.id,
         props: {
@@ -253,6 +253,7 @@ export function serverChildrenToEditorChildren(
           textColor: 'default',
           textAlignment: 'left',
           defaultOpen: 'false',
+          ...opts,
         },
         content: serverBlockToEditorInline(serverBlock.block),
         children: serverChildrenToEditorChildren(serverBlock.children),
@@ -260,7 +261,7 @@ export function serverChildrenToEditorChildren(
     }
 
     if (serverBlock.block?.type === 'file') {
-      return {
+      res = {
         type: 'file',
         id: serverBlock.block.id,
         props: {
@@ -270,13 +271,14 @@ export function serverChildrenToEditorChildren(
           textColor: 'default',
           textAlignment: 'left',
           defaultOpen: 'false',
+          ...opts,
         },
         children: serverChildrenToEditorChildren(serverBlock.children),
       }
     }
 
     if (serverBlock.block?.type === 'embed') {
-      return {
+      res = {
         type: 'embed',
         id: serverBlock.block.id,
         props: {
@@ -284,6 +286,7 @@ export function serverChildrenToEditorChildren(
           backgroundColor: 'default',
           textColor: 'default',
           textAlignment: 'left',
+          ...opts,
         },
         children: serverChildrenToEditorChildren(serverBlock.children),
       }
@@ -292,7 +295,7 @@ export function serverChildrenToEditorChildren(
     // how to handle when serverBlock.type is 'heading' but we are inside of a list?
     // for now, we prioritize the node type
     if (serverBlock.block?.type === 'heading') {
-      return serverBlockToHeading(serverBlock, childRecursiveOpts)
+      res = serverBlockToHeading(serverBlock, childRecursiveOpts)
     }
     // if (opts?.childrenType === 'numbers') {
     //   return serverBlockToEditorOLI(serverBlock, childRecursiveOpts)
@@ -300,6 +303,17 @@ export function serverChildrenToEditorChildren(
     // if (opts?.childrenType === 'bullet') {
     //   return serverBlockToEditorULI(serverBlock, childRecursiveOpts)
     // }
-    return serverBlockNodeToEditorParagraph(serverBlock, childRecursiveOpts)
+    res = serverBlockNodeToEditorParagraph(serverBlock, childRecursiveOpts)
+
+    if (serverBlock.block?.attributes.childrenType) {
+      // @ts-expect-error
+      res.props.childrenType = serverBlock.block.attributes.childrenType
+    }
+
+    if (serverBlock.block?.attributes.start) {
+      res.props.start = serverBlock.block.attributes.start
+    }
+
+    return res
   })
 }


### PR DESCRIPTION
This PR aims to support different blockgroup types in the editor.

### TLDR:
- the Hyperdocs data structure will not change
- the editor structure is not changing
- we are adding two new attributes: `childrenType` and `start` (both non-required)
- `childrenType` is a union: `'group' | 'ol' | 'ul' | 'blockquote'`
- `start` is a string but is treated as a number
- `childrenType` aims to change not only UI but HTML semantics

---

the editor structure follows this structure:

```
<blockgroup>
    <block>
        <content>Parent element 1</content>
        <blockgroup>
            <block>
                <content>Nested / child / indented item</content>
            </block>
        </blockgroup>
    </block>
    <block>
        <content>Parent element 2</content>
        <blockgroup>
            <block>...</block>
            <block>...</block>
        </blockgroup>
    </block>
    <block>
        <content>Element 3 without children</content>
    </block>
</blockgroup>
```

From the schema we have access inside the editor, we only have the ability to add properties to blocks. so we need to add the blockGroup type information to the parent block

Here's how the Editor structure is with this change:

```ts
export type HDBlockChildrenType = 'group' | 'ol' | 'ul' | 'blockquote'

export type HDBlockAttributes = {
  childrenType?: HDBlockChildrenType // default is "group"
  start?: string // interpret as a number
  showContent?: string // interpret as a bool
}

export type ParagraphBlock = {
  id: string
  type: 'paragraph'
  text: string
  attributes: HDBlockAttributes
  annotations: TextAnnotation[]
}

export type HeadingBlock = {
  id: string
  type: 'heading'
  text: string
  attributes: HDBlockAttributes
  annotations: TextAnnotation[]
}

export type CodeBlock = {
  id: string
  type: 'code'
  content: string
  attributes: {
    lang: string
  }
}

export type ImageBlock = {
  // and any media object really
  id: string
  type: 'image'
  content: ''
  annotations: []
  ref: string // ipfs://..., https://...
  attributes: HDBlockAttributes & {
    alt?: string
  }
}

export type EmbedBlock = {
  id: string
  type: 'embed'
  content: ''
  ref: string // ipfs://..., https://...
  attributes: HDBlockAttributes
}

export type PresentationBlock =
  | ImageBlock // video and files coming soon
  | EmbedBlock
  | ParagraphBlock
  | HeadingBlock
  | CodeBlock

// annotations below...
```

